### PR TITLE
fix: Add netlify.toml for correct deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Netlify configuration file for a Next.js project.
+
+[build]
+  # Command to build the project.
+  command = "npm run build"
+
+  # The directory to publish, which is the output of the build command.
+  # For Next.js, this is the .next directory.
+  publish = ".next"
+
+# This plugin is essential for deploying Next.js sites on Netlify.
+# It automatically configures redirects, serverless functions, and other
+# necessary settings for Next.js features to work correctly.
+[[plugins]]
+  package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
This commit adds a `netlify.toml` configuration file to ensure the project deploys correctly on Netlify.

The file specifies the build command, the publish directory (`.next`), and includes the essential `@netlify/plugin-nextjs` plugin. This configuration is necessary for Netlify to correctly handle the server-side rendering, static generation, and other features of a Next.js application, resolving the 'Page not found' (404) error on deployment.