### PR TITLE
feat: Implement PWA offline status indicator

### DIFF
--- a/components/pwa-status-icon.tsx
+++ b/components/pwa-status-icon.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Wifi, WifiOff, CheckCircle } from "lucide-react";
+import { useToast } from "./ui/use-toast";
+
+export function PwaStatusIcon() {
+    const [isOfflineReady, setIsOfflineReady] = useState(false);
+    const [isChecking, setIsChecking] = useState(false);
+    const { toast } = useToast();
+
+    useEffect(() => {
+        // This effect runs once on mount to check the initial state
+        if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+            // If a service worker is already controlling the page, it's ready for offline use.
+            if (navigator.serviceWorker.controller) {
+                setIsOfflineReady(true);
+            }
+            // Listen for when a new service worker takes control.
+            navigator.serviceWorker.addEventListener('controllerchange', () => {
+                setIsOfflineReady(true);
+            });
+        }
+    }, []);
+
+    const handleIconClick = async () => {
+        if (!('serviceWorker' in navigator)) {
+            toast({ variant: "destructive", title: "متصفحك لا يدعم هذه الميزة." });
+            return;
+        }
+
+        setIsChecking(true);
+        toast({ title: "جاري التحقق من وجود تحديثات..." });
+
+        try {
+            // Get the service worker registration.
+            const registration = await navigator.serviceWorker.ready;
+            // Manually check for updates on the server.
+            await registration.update();
+
+            // The update process happens in the background. The 'controllerchange'
+            // event will fire if a new worker takes control.
+            toast({ title: "اكتمل التحقق.", description: "إذا كان هناك تحديث، سيتم تطبيقه في الخلفية." });
+
+        } catch (error) {
+            toast({ variant: "destructive", title: "فشل التحقق من التحديثات." });
+        } finally {
+            setTimeout(() => setIsChecking(false), 2000);
+        }
+    };
+
+    let icon = <WifiOff className="h-[1.2rem] w-[1.2rem]" />;
+    let tooltipText = "التطبيق ليس جاهزًا للعمل بدون إنترنت. اضغط للتحضير.";
+
+    if (isOfflineReady) {
+        icon = <Wifi className="h-[1.2rem] w-[1.2rem] text-green-500" />;
+        tooltipText = "التطبيق جاهز للعمل بدون إنترنت.";
+    }
+
+    if (isChecking) {
+        icon = <CheckCircle className="h-[1.2rem] w-[1.2rem] animate-pulse" />;
+        tooltipText = "جاري التحقق...";
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon" onClick={handleIconClick} disabled={isChecking}>
+                    {icon}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+                <p>{tooltipText}</p>
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/components/top-bar.tsx
+++ b/components/top-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Menu, Moon, Sun, ShieldCheck, WifiOff } from "lucide-react";
+import { Menu, Moon, Sun, ShieldCheck } from "lucide-react";
 import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { cn } from "@/lib/utils";
 import { useToast } from "./ui/use-toast";
 import { useAppContext } from "@/context/app-context";
+import { PwaStatusIcon } from "./pwa-status-icon";
 
 export function TopBar() {
   const {
@@ -66,16 +67,7 @@ export function TopBar() {
           </Tooltip>
 
           <div className="flex flex-1 items-center justify-end space-x-2 rtl:space-x-reverse">
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button variant="ghost" size="icon" disabled>
-                        <WifiOff className="h-[1.2rem] w-[1.2rem]" />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                    <p>قيد التطوير</p>
-                </TooltipContent>
-            </Tooltip>
+            <PwaStatusIcon />
 
             <Tooltip>
               <TooltipTrigger asChild>

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":app/encoding.test.ts",{"duration":44.627580999999964,"failed":false}]]}
+{"version":"3.2.4","results":[[":app/encoding.test.ts",{"duration":26.872232000000054,"failed":false}]]}


### PR DESCRIPTION
This commit introduces a new UI feature to inform the user about the application's offline readiness, fulfilling the request to make the 'offline' icon functional.

- A new component, `pwa-status-icon.tsx`, has been created to encapsulate all logic related to PWA state detection.
- This component uses the `navigator.serviceWorker` API to check if a service worker is currently controlling the page, which indicates that the app's assets are cached for offline use.
- The icon in the top bar now dynamically changes to reflect the offline status (`WifiOff` vs. `Wifi`).
- Clicking the icon now triggers a check for service worker updates, giving the user a way to manually refresh the app's cache.